### PR TITLE
Fix race condition between ssh and writable mount

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,60 +1,59 @@
 pipeline {
   agent any
   stages {
-    stage('Preparation') {
-      steps {
-        dir(path: 'source') {
-          git 'https://github.com/ubports/lxc-android-config.git'
-        }
-        
-      }
-    }
     stage('Build source') {
       steps {
-        sh 'rm -f ./* || true'
-        sh '''cd source
-export GIT_COMMIT=$(git rev-parse HEAD)
-export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-cd ..
-export KEEP_SOURCE_CHANGES=true
-/usr/bin/generate-git-snapshot
-dput ppa:ubports-developers/overlay *.changes
-rm *.changes'''
+        sh '/usr/bin/build-source.sh'
         stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
     stage('Build binary - armhf') {
       steps {
-        node(label: 'xenial-arm64') {
-          unstash 'source'
-          sh '''export architecture="armhf"
-export distribution="xenial"
-export REPOS="xenial"
-export BUILD_ONLY=true
-export DEB_BUILD_OPTIONS="parallel=$(nproc) nocheck"
-/usr/bin/generate-reprepro-codename "${REPOS}"
-/usr/bin/build-and-provide-package'''
-          stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build')
-          cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
-        }
-        
+        parallel(
+          "Build binary - armhf": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="armhf"
+build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+
+
+          },
+          "Build binary - arm64": {
+            node(label: 'arm64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="arm64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          },
+          "Build binary - amd64": {
+            node(label: 'amd64') {
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+              unstash 'source'
+              sh '''export architecture="amd64"
+    build-binary.sh'''
+              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+            }
+          }
+        )
       }
     }
     stage('Results') {
       steps {
-        unstash 'build'
+        cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
+        unstash 'build-armhf'
+        unstash 'build-arm64'
+        unstash 'build-amd64'
         archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
-        sh '''export architecture="armhf"
-export release="xenial"
-mkdir -p binaries
-
-for suffix in gz bz2 xz deb dsc changes ; do
-  mv *.${suffix} binaries/ || true
-done
-
-export BASE_PATH="binaries/"
-export PROVIDE_ONLY=true
-/usr/bin/build-and-provide-package'''
+        sh '''/usr/bin/build-repo.sh'''
       }
     }
     stage('Cleanup') {

--- a/etc/init/ssh-keygen.conf
+++ b/etc/init/ssh-keygen.conf
@@ -2,9 +2,4 @@ start on starting ssh
 
 task
 
-script
-    [ ! -e /etc/ssh/ssh_host_rsa_key ] && \
-            ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >/dev/null 2>&1
-    [ ! -e /etc/ssh/ssh_host_dsa_key ] && \
-            ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa >/dev/null 2>&1
-end script
+exec /usr/bin/ssh-keygen.sh

--- a/usr/bin/ssh-keygen.sh
+++ b/usr/bin/ssh-keygen.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# Sometimes /etc/ssh isn't writable when this job starts. Work around that.
+# For some reason we can't rely on 'mounted /etc/ssh', it doesn't always fire
+check-writable() {
+    while [ ! $WRITABLE ]; do
+        touch /etc/ssh/testfile && {
+            rm /etc/ssh/testfile
+            WRITABLE=true
+            break
+        }
+        sleep 1
+    done
+}
+
+if [ ! -e /etc/ssh/ssh_host_rsa_key ]; then
+    check-writable
+    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
+fi
+if [ ! -e /etc/ssh/ssh_host_dsa_key ]; then
+    check-writable
+    ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
+fi


### PR DESCRIPTION
This adds the `/usr/bin/ssh-keygen.sh` script, which waits for
`/etc/ssh` to become writable before actually generating the keys.
This is needed by the Nexus 5X as the ssh-keygen job starts before
`/etc/ssh` is mounted.
Normally you'd work around this problem by specifying another
condition in the Upstart job, such as `start on mounted /etc/ssh`, but
I wasn't able to get this working reliably.