### PR TITLE
Fix for ubports/ubuntu-touch#444

### DIFF
--- a/etc/init/ssh-property-watcher.conf
+++ b/etc/init/ssh-property-watcher.conf
@@ -3,8 +3,8 @@ start on android-container persist.service.ssh=*
 task
 
 script
-    VAL=$(env | grep persist.service.ssh=)
-    case ${VAL##*=} in
+    VAL=$(getprop "persist.service.ssh")
+    case ${VAL} in
         true)
             start ssh
         ;;


### PR DESCRIPTION
In 16.04, sshd does not start when `android-gadget-service enable ssh`
is run.  This is because the `ssh-property-watcher` job exits with
status 1 after trying to get the environment variable
`persist.service.ssh`.  Instead of getting this from the environment,
we'll use `getprop` to get it directly instead.