### PR TITLE
Fix race condition between ssh job and /etc/ssh mount

### DIFF
--- a/etc/init/ssh-keygen.conf
+++ b/etc/init/ssh-keygen.conf
@@ -2,9 +2,4 @@ start on starting ssh
 
 task
 
-script
-    [ ! -e /etc/ssh/ssh_host_rsa_key ] && \
-            ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa >/dev/null 2>&1
-    [ ! -e /etc/ssh/ssh_host_dsa_key ] && \
-            ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa >/dev/null 2>&1
-end script
+exec /usr/bin/ssh-keygen.sh

--- a/usr/bin/ssh-keygen.sh
+++ b/usr/bin/ssh-keygen.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Sometimes /etc/ssh isn't writable when the ssh job starts. Also, for some 
+# reason we can't rely on the 'mounted /etc/ssh' event, it doesn't always fire.
+# This script works around both of those problems.
+wait-for-writable() {
+    while [ ! $WRITABLE ]; do
+        touch /etc/ssh/testfile && {
+            rm /etc/ssh/testfile
+            WRITABLE=true
+            break
+        }
+        sleep 1
+    done
+}
+
+if [ ! -e /etc/ssh/ssh_host_rsa_key ]; then
+    wait-for-writable
+    ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
+fi
+if [ ! -e /etc/ssh/ssh_host_dsa_key ]; then
+    wait-for-writable
+    ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
+fi

--- a/usr/bin/ssh-keygen.sh
+++ b/usr/bin/ssh-keygen.sh
@@ -3,7 +3,7 @@
 # Sometimes /etc/ssh isn't writable when the ssh job starts. Also, for some 
 # reason we can't rely on the 'mounted /etc/ssh' event, it doesn't always fire.
 # This script works around both of those problems.
-wait-for-writable() {
+wait_for_writable() {
     while [ ! $WRITABLE ]; do
         touch /etc/ssh/testfile && {
             rm /etc/ssh/testfile
@@ -15,10 +15,10 @@ wait-for-writable() {
 }
 
 if [ ! -e /etc/ssh/ssh_host_rsa_key ]; then
-    wait-for-writable
+    wait_for_writable
     ssh-keygen -f /etc/ssh/ssh_host_rsa_key -N '' -t rsa
 fi
 if [ ! -e /etc/ssh/ssh_host_dsa_key ]; then
-    wait-for-writable
+    wait_for_writable
     ssh-keygen -f /etc/ssh/ssh_host_dsa_key -N '' -t dsa
 fi


### PR DESCRIPTION
When we set the ssh job to `start on startup` during development, the job sometimes tries to start before `mountall` has mounted `/etc/ssh` to its writable point on `/userdata`.

This solution isn't the most elegant, and I've tried the following others before resorting to this:

* Setting the ssh job to `start on filesystem`
* Setting the ssh job to `start on mounted /etc/ssh`

Neither worked.