### PR TITLE
Add temporary path for openVPN

### DIFF
--- a/etc/system-image/writable-paths
+++ b/etc/system-image/writable-paths
@@ -22,6 +22,7 @@
 /var/lib/logrotate                      auto                    persistent  none        none
 /var/lib/NetworkManager                 auto                    persistent  none        none
 /var/lib/ofono                          auto                    persistent  none        none
+/var/lib/openvpn/chroot/tmp             auto                    temporary   none        defaults
 /var/lib/PackageKit                     auto                    persistent  none        none
 /var/lib/bluetooth                      auto                    persistent  none        none
 /var/lib/lightdm                        auto                    persistent  none        none


### PR DESCRIPTION
Fixes ubports/ubuntu-touch#689 by making a new path for openVPN.