### PR TITLE
Add udev rule to create /dev/video symlinks

### DIFF
--- a/lib/udev/rules.d/99-z-video.rules
+++ b/lib/udev/rules.d/99-z-video.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="video4linux", ATTR{link_name}=="?*", SYMLINK+="video/$attr{link_name}"


### PR DESCRIPTION
This fixes https://github.com/ubports/ubuntu-touch/issues/661

OMG this was lot of "looking in the completely wrong place" to be able to fix... remind me to use strace more often :)