### PR TITLE
Remove whoopsie from fstab

### DIFF
--- a/etc/system-image/writable-paths
+++ b/etc/system-image/writable-paths
@@ -64,9 +64,6 @@
 /var/lib/urfkill                        auto                    persistent  transition  none
 # needed for usb tethering
 /var/lib/misc                           auto                    persistent  transition  none
-# whoopsie
-/var/lib/whoopsie                       auto                    persistent  transition  none
-/etc/init/whoopsie.override             auto                    persistent  transition  none
 # needed to persist ntp enabled/disabled
 /etc/network/if-up.d                    auto                    persistent  transition  none
 # snappy


### PR DESCRIPTION
Got a hint to that location(s) during apt autoremoving whoopsie "Device busy"...