### PR TITLE
Disable QtWebEngine GPU

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lxc-android-config (0.232+ubports0) xenial; urgency=medium
+
+  * Disable QtWebEngine GPU
+
+ -- Dalton Durst <dalton@ubports.com>  Fri, 09 Nov 2018 16:34:27 -0600
+
 lxc-android-config (0.231+ubports1) xenial; urgency=medium
 
   * Backport to xenial 

--- a/etc/profile.d/disable-qtwebengine-gpu.sh
+++ b/etc/profile.d/disable-qtwebengine-gpu.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Disable the GPU for QtWebEngine on Android-based devices
+# This file is part of lxc-android-config
+export QT_WEBENGINE_DISABLE_GPU=1


### PR DESCRIPTION
This commit disables the GPU in our builds of QtWebEngine ([patch here](https://github.com/ubports/qtwebengine-opensource-src-packaging/blob/xenial/debian/patches/qtwebengine-no-gpu.patch)) so that it doesn't fail to start OpenGL and die.