### PR TITLE
Start zram-touch on android-container

### DIFF
--- a/etc/init/zram-touch.conf
+++ b/etc/init/zram-touch.conf
@@ -1,4 +1,4 @@
-start on started lxc-android-config
+start on android-container
 
 task
 


### PR DESCRIPTION
For whatever reason, 'started lxc-android-config' isn't getting emitted on xenial. 'android-container' is emitted, though, so we can start this job at the appropriate time.

This fixes ubports/ubuntu-touch#965