### PR TITLE
Replace pre-start.sh for halium-boot

### DIFF
--- a/var/lib/lxc/android/pre-start.sh
+++ b/var/lib/lxc/android/pre-start.sh
@@ -1,16 +1,18 @@
+
 #!/bin/sh
 
-if [ -e /android/system/boot/android-ramdisk.img ]; then
-    INITRD=/android/system/boot/android-ramdisk.img
-elif [ -e /boot/android-ramdisk.img ]; then
-    rm -Rf $LXC_ROOTFS_PATH
-    mkdir -p $LXC_ROOTFS_PATH
-    INITRD=/boot/android-ramdisk.img
-    cd $LXC_ROOTFS_PATH
-    cat $INITRD | gzip -d | cpio -i
-else
-    exit 1
-fi
+for mountpoint in /android/*; do
+	mount_name=`basename $mountpoint`
+	desired_mount=$LXC_ROOTFS_PATH/$mount_name
+
+	# Remove symlinks, for example bullhead has /vendor -> /system/vendor
+	[ -L $desired_mount ] && rm $desired_mount
+
+	[ -d $desired_mount ] || mkdir $desired_mount
+	mount --bind $mountpoint $desired_mount
+done
+
+mknod -m 666 $LXC_ROOTFS_PATH/dev/null c 1 3
 
 # Create /dev/pts if missing
 mkdir -p $LXC_ROOTFS_PATH/dev/pts
@@ -19,20 +21,13 @@ mkdir -p $LXC_ROOTFS_PATH/dev/pts
 mkdir -p /dev/socket $LXC_ROOTFS_PATH/socket
 mount -n -o bind,rw /dev/socket $LXC_ROOTFS_PATH/socket
 
-# run config snippet scripts
-run-parts /var/lib/lxc/android/pre-start.d || true
+rm $LXC_ROOTFS_PATH/sbin/adbd
 
 sed -i '/on early-init/a \    mkdir /dev/socket\n\    mount none /socket /dev/socket bind' $LXC_ROOTFS_PATH/init.rc
 
-if [ "$INITRD" = "/android/system/boot/android-ramdisk.img" ]; then
-    sed -i "/mount_all /d" $LXC_ROOTFS_PATH/init.*.rc
-    sed -i "/on nonencrypted/d" $LXC_ROOTFS_PATH/init.rc
+sed -i "/mount_all /d" $LXC_ROOTFS_PATH/init.*.rc
+sed -i "/swapon_all /d" $LXC_ROOTFS_PATH/init.*.rc
+sed -i "/on nonencrypted/d" $LXC_ROOTFS_PATH/init.rc
 
-    rm -Rf $LXC_ROOTFS_PATH/vendor
-    ln -s /system/vendor $LXC_ROOTFS_PATH/vendor
-
-    for dir in /android/*; do
-        mkdir -p $LXC_ROOTFS_PATH/$(basename $dir)
-        mount -n -o bind,recurse $dir $LXC_ROOTFS_PATH/$(basename $dir)
-    done
-fi
+# Config snippet scripts
+run-parts /var/lib/lxc/android/pre-start.d || true


### PR DESCRIPTION
This change is part of the fix for ubports/ubuntu-touch#404

Replace the pre-start.sh file with one that combines changes for Plasma Mobile and ourselves. This allows us to use halium-boot and does not negatively affect ubports-boot or the legacy Canonical initramfs.