### PR TITLE
Revert "Add qtubuntu-sensors as default sensors"

### DIFF
--- a/etc/xdg/QtProject/Sensors.conf
+++ b/etc/xdg/QtProject/Sensors.conf
@@ -1,2 +1,0 @@
-[Default]
-QOrientationSensor = core.orientation


### PR DESCRIPTION
Reverts ubports/lxc-android-config#22

We can't have this config file in lxc-android-config as long as it's [here](https://github.com/ubports/qtubuntu-sensors/blob/xenial/data/Sensors.conf).