### PR TITLE
Let ueventd do the coldplug

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+lxc-android-config (0.233+ubports0) xenial; urgency=medium
+
+  * Starts udev before Android container and let ueventd do the coldplug.
+
+ -- Ratchanan Srirattanamet <peathot@hotmail.com>  Mon, 26 Aug 2019 14:55:13 +0700
+
 lxc-android-config (0.232+ubports0) xenial; urgency=medium
 
   * Disable QtWebEngine GPU

--- a/debian/lxc-android-config.upstart
+++ b/debian/lxc-android-config.upstart
@@ -4,7 +4,7 @@
 
 description "lxc android config and container initialization"
 
-start on cgmanager-ready and started cgroup-lite
+start on cgmanager-ready and started cgroup-lite and started udev
 stop on runlevel [06]
 
 pre-start script

--- a/etc/init/udev.override
+++ b/etc/init/udev.override
@@ -5,8 +5,7 @@
 
 description     "device node and kernel event manager"
 
-start on (android
-          and stopped lxc-android-boot)
+start on stopped lxc-android-boot
 stop on runlevel [06]
 
 expect fork

--- a/etc/init/udevtrigger.override
+++ b/etc/init/udevtrigger.override
@@ -1,0 +1,23 @@
+# udevtrigger - cold plug devices
+#
+# By the time udevd starts, we've already missed all of the events for
+# the devices populated in /sys.  This task causes the kernel to resend
+# them.
+
+# This version of udevtrigger job is updated to account the fact that
+# android's ueventd does its own "coldboot". To prevent double-coldbooting,
+# this task is changed to wait to "android" upstart event, which is guaranteed
+# to happen after ueventd's coldboot is done. Then, the only thing left to do
+# is to run "udevadm settle".
+
+description	"cold plug devices"
+
+start on (startup
+          and started udev
+          and android
+          and not-container)
+
+task
+
+exec /bin/true
+post-stop exec udevadm settle


### PR DESCRIPTION
This commit makes udev start before Android container and let ueventd do
the coldplug. This prevent double coldboot/coldplug and make camera
works on FP2 with Halium 7.1 port.

On FP2 with Halium 7.1, mm-qcamera-daemon happens to start in the
container at approx. the same time with udevtrigger job. As part of
daemon's startup, it talks to some kernel interface to init camera
sensor's v4l-subdev's and expect them to appear shortly after that. But
with overwhelming amount of uevents generate by udevtrigger, Android's
ueventd takes some time until it can create such device nodes. This make
the daemon fails to find the device node and assume that initialisation
fails. By preventing double coldboot/coldplug, ueventd will be able to
create such device nodes in time, making the camera works.

How to test
-------------

- Unmount the file bind-mounted from Android: `sudo umount /lib/udev/rules.d/70-android.rules`
- Installs 2 debs. Especially for E4.5, the 2nd deb fixes the reported regression about Wi-Fi at boot.
  - [`lxc-android-config_0.233+ubports0+0~20200701150715.8~1.gbpff82e8_all.deb`](https://ci.ubports.com/job/ubports/job/lxc-android-config/job/PR-26/8/artifact/lxc-android-config_0.233+ubports0+0~20200701150715.8~1.gbpff82e8_all.deb)
  - [`urfkill_0.7.0+ubports+0~20200105190143.1~1.gbp696ec1_armhf.deb`](https://ci.ubports.com/job/urfkill-packaging/job/PR-3/1/artifact/urfkill_0.7.0+ubports+0~20200105190143.1~1.gbp696ec1_armhf.deb)
- If you encountered `unable to make backup link of '<a path>' before installing new version: Invalid cross-device link` error, unmount it by running `sudo umount <path without the prepending dot>` and try again.
- Finally, reboot.

Try reboot multiple times. Optionally, factory-reset your phone and re-test.