### PR TITLE
Make rild unit understands Android multisim property

### DIFF
--- a/etc/init/rild.conf
+++ b/etc/init/rild.conf
@@ -18,6 +18,16 @@ script
     done
 
     RIL_DEVICE="$(getprop ril.device ril)"
-    RIL_NUM_SIM_SLOTS="$(getprop ril.num_slots 1)"
+    RIL_NUM_SIM_SLOTS="$(getprop ril.num_slots)"
+
+    if [ -z "$RIL_NUM_SIM_SLOTS" ]; then
+        # https://android.googlesource.com/platform/frameworks/base.git/+/android-7.1.2_r1/telephony/java/android/telephony/TelephonyManager.java
+        case "$(getprop persist.radio.multisim.config)" in
+            dsds|dsda) RIL_NUM_SIM_SLOTS=2 ;;
+            tsts) RIL_NUM_SIM_SLOTS=3 ;;
+            *) RIL_NUM_SIM_SLOTS=1 ;;
+        esac
+    fi
+
     initctl emit rild-ready OFONO_RIL_DEVICE=$RIL_DEVICE OFONO_RIL_NUM_SIM_SLOTS=$RIL_NUM_SIM_SLOTS
 end script


### PR DESCRIPTION
rild.conf already uses the property named ril.num_slots to determine the
number of SIM slots. However, this property is Ubuntu Touch specific.
Meanwhile, Android (at least since version 5.0) uses the property named
persist.radio.multisim.config to indicates the multi-sim configuration
for the device. Thus, by supporting this property, porters will not have
to set the Ubuntu Touch specific property before they get multi-sim on
their device.

Update: turns out, we have to also update telepathy-ofono not to depends on `ril.num_slots`. I might do it at a later time. Meanwhile, this is probably safe to merge.