### PR TITLE
Make rild unit detect legacy cap switch

### DIFF
--- a/etc/init/rild.conf
+++ b/etc/init/rild.conf
@@ -29,5 +29,18 @@ script
         esac
     fi
 
-    initctl emit rild-ready OFONO_RIL_DEVICE=$RIL_DEVICE OFONO_RIL_NUM_SIM_SLOTS=$RIL_NUM_SIM_SLOTS
+    FLEXMAP_TYPE="$(getprop persist.radio.flexmap_type)"
+    case "$FLEXMAP_TYPE" in
+        none)
+            RIL_LEGACY_CAP_SWITCH=1 ;;
+        *)
+            # FIXME: what about other values? I've seen "dds" (uses modern cap
+            # switch) and "nw_mode" (no idea what is it for).
+            RIL_LEGACY_CAP_SWITCH=0 ;;
+    esac
+
+    initctl emit rild-ready \
+        OFONO_RIL_DEVICE=$RIL_DEVICE \
+        OFONO_RIL_NUM_SIM_SLOTS=$RIL_NUM_SIM_SLOTS \
+        OFONO_RIL_LEGACY_CAP_SWITCH=$RIL_LEGACY_CAP_SWITCH
 end script


### PR DESCRIPTION
Property "persist.radio.flexmap_type" seems to define how capability
switching happens on the device. Android will do capability switching if
this property is set to "dds" [1]. On some device (such as FP2), this
value is set to "none", which inhibit switching. That means switching 4G
SIM slot must be done by demoting another slot to 2G manually first [2].

On Ubuntu Touch, we want to map this to our "legacy cap switch" which
automates the process of setting the other slot to 2G. This is
implemented in oFono (Sees [3]).

[1] https://github.com/LineageOS/android_frameworks_opt_telephony/blob/cm-14.1/src/java/com/android/internal/telephony/SubscriptionController.java#L1470

[2] It seems like older version of Android (at least in CyanogenMod)
supports automating this.
https://github.com/LineageOS/android_packages_services_Telephony/commit/d52fec7dca1a2aa7db8086b103fe1e890ce0ca94

[3] https://github.com/ubports/ofono/pull/5