### PR TITLE
Add override-vibrator-permission unit

### DIFF
--- a/etc/init/override-vibrator-permission.conf
+++ b/etc/init/override-vibrator-permission.conf
@@ -1,0 +1,10 @@
+description "Allow any user to use the vibrator driver"
+author "Ratchanan Srirattanamet <ratchanan@ubports.com>"
+
+# Temporarily allowing any user to use the vibrator driver
+# until we have a better way to control its access.
+
+start on file FILE=/sys/class/timed_output/vibrator/enable EVENT=create
+
+task
+exec chmod 666 /sys/class/timed_output/vibrator/enable


### PR DESCRIPTION
This unit change the permission of the vibrator device to 666 to allow
normal users to use the vibrator. This is the equivalent of the patch in
5.1-based Android tree [1]. However, this method requires no change in
Halium Android tree.

[1] https://github.com/ubports/android_system_core/commit/140632c0a4e25275afc1375ad3f8d5c420e583ec