### PR TITLE
Make lxc container starts in foreground

### DIFF
--- a/debian/lxc-android-config.upstart
+++ b/debian/lxc-android-config.upstart
@@ -14,7 +14,7 @@ pre-start script
     fi
 end script
 
-exec lxc-start -n android -d -- /init
+exec lxc-start -n android -F -- /init
 
 post-start script
     if [ ! -d /dev/cpuctl ] && [ -d /sys/fs/cgroup/cpu ]; then

--- a/etc/init/zram-touch.conf
+++ b/etc/init/zram-touch.conf
@@ -1,4 +1,4 @@
-start on android-container
+start on started lxc-android-config
 
 task
 


### PR DESCRIPTION
Commit a81b8e4b97a168ec1474a96675fa94f348e456bf (Updating lxc-android
-config to work with new lxc v2.0) makes the container starts in the
background by changing the flag -F to -d. This cause Upstart to confuse
and think that the container stopped very early, which affects the
emitted signal.

This commit change the -d flag back to -F, which should make sure that
any unit relying on "started lxc-android-config" can work properly.

This also allows zram-touch unit to rely on this signal. As such, I've decided
to revert commit cf53c2d (Start zram-touch on android-container).