### PR TITLE
Add override-leds-permission unit

### DIFF
--- a/etc/init/override-leds-permission.conf
+++ b/etc/init/override-leds-permission.conf
@@ -1,0 +1,30 @@
+description "Allow users in 'android_input' group to use LEDs"
+author "Ratchanan Srirattanamet <ratchanan@ubports.com>"
+
+# Make LED files writable for the (Android's) input group, so the phablet user
+# can also access it (and we can use the lights hal as phablet).
+
+# To be future-proof, instead of hard-coding list of files to chown/chmod,
+# use "find" to find all files applicable. It search for only 1 level deep and
+# exclude "uevent" and "trigger" to not introduce vulnerability.
+
+start on android and filesystem
+task
+
+script
+    # Android's init.rc set these files' property in "on boot" event, which
+    # happens significantly after "android" upstart event. If we run too early,
+    # our work will be overwritten by init.rc.
+
+    # To solve this issue, wait for this specific property to be set, which
+    # is the last thing Android does in init.rc's "on boot" section.
+    # https://github.com/Halium/android_system_core/blob/e8d89cb8265c2f4e53a133256486a37bba787a8a/rootdir/init.rc#L586
+    # FIXME: There should be a better way to do this.
+
+    while [ -z "$(getprop net.tcp.default_init_rwnd)" ]; do sleep 1; done
+
+    exec find /sys/class/leds/*/ -maxdepth 1 -type f \
+        ! -name uevent ! -name trigger \
+        -exec chown system:android_input '{}' '+' \
+        -exec chmod 664 '{}' '+'
+end script


### PR DESCRIPTION
THis unit change the permission of LED files under `/sys/class/leds` so
that phablet user can also access it (and we can use the lights hal as
phablet). This is the equivalent of the patch in 5.1-based Android tree
[1]. However, this method requires no change in Halium Android tree and
cover more files without us explicitly writing them out.

[1] https://github.com/ubports/android_system_core/commit/bd405d14f8189470baf00065f09d76fc4b45298b