### PR TITLE
Fix waiting for "on boot" in Android 4.4

### DIFF
--- a/etc/init/override-leds-permission.conf
+++ b/etc/init/override-leds-permission.conf
@@ -17,11 +17,23 @@ script
     # our work will be overwritten by init.rc.
 
     # To solve this issue, wait for this specific property to be set, which
-    # is the last thing Android does in init.rc's "on boot" section.
+    # is the last thing Android 5+ does in init.rc's "on boot" section.
     # https://github.com/Halium/android_system_core/blob/e8d89cb8265c2f4e53a133256486a37bba787a8a/rootdir/init.rc#L586
+    
+    # "This specific property" is different for Android 4.4
+    # https://github.com/peat-psuwit/ubuntu-phone_system_core/blob/244d3b9db762b6c1fc319fdca16c7d1c0264802a/rootdir/init.rc#L377
+
     # FIXME: There should be a better way to do this.
 
-    while [ -z "$(getprop net.tcp.default_init_rwnd)" ]; do sleep 1; done
+    # Don't wait forever. Some device may not even set this property.
+    TIMEOUT=15
+    COUNT=0
+    while [ -z "$(getprop net.tcp.default_init_rwnd)" ] && \
+          [ -z "$(getprop net.tcp.buffersize.default)" ] && \
+          [ "$COUNT" -lt "$TIMEOUT" ]; do 
+        sleep 1
+        COUNT=$(( COUNT + 1 ))
+    done
 
     exec find /sys/class/leds/*/ -maxdepth 1 -type f \
         ! -name uevent ! -name trigger \


### PR DESCRIPTION
Turns out the property we wait for isn't always set on all devices.
On Android 4.4 devices, we have to look for another property. And in
case even that is not set, we have timeout failback to not prevent the
rest of the system to continue.

This fixes the completion of lxc-android-config job, which in turns
fixes zram on some devices.