### PR TITLE
Ensure Android's property_service is ready

### DIFF
--- a/debian/lxc-android-config.upstart
+++ b/debian/lxc-android-config.upstart
@@ -29,9 +29,16 @@ post-start script
             sleep 0.1
         done
 
+        # If the socket isn't available, 'getprop' falls back to reading files
+        # manually, causing a false positive of propertyservice being up
+        while [ ! -e /dev/socket/property_service ]; do sleep 0.1; done
+
+        # This property is read by libhybris itself to pick a linker, so it
+        # *MUST* be available before we emit 'android'.
+        while [ -z "$(getprop ro.build.version.sdk)" ]; do sleep 0.1; done
+
         # Allow custom properties before announcing that the boot is completed
         if [ -f /custom/custom.prop ]; then
-            while [ ! -e /dev/socket/property_service ]; do sleep 0.1; done
             grep "^custom\." /custom/custom.prop | sed 's/=/ /' | while read property value; do
                 setprop $property $value
             done


### PR DESCRIPTION
Prior to this commit, we could emit 'android' and cause programs to
start prior to property_service actually listening on its socket. This
would cause "" (empty string) to be returned for any property requests.
Most notably, this caused Libhybris-linked software to start with the
wrong linker, leading to unpredictable behavior.

Fixes https://github.com/ubports/ubuntu-touch/issues/1493