### PR TITLE
Don't change rfkill's group to android_input

### DIFF
--- a/lib/udev/rules.d/85-android.rules
+++ b/lib/udev/rules.d/85-android.rules
@@ -1,2 +1,0 @@
-# rfkill
-ACTION=="add", KERNEL=="rfkill", GROUP="android_input", MODE="0660"


### PR DESCRIPTION
The /dev/rfkill device was set to the android_input group in a commit before the current git repository can even remember. We later ensured that it happened by setting the group even later, in  3e1871d. But the correct solution is actually to add phablet to the netdev group, which the rfkill device is owned by on a Debian system, and drop this rule.

This commit requires all-device testing, and is absolutely not valid for merge before the OTA-13 release.